### PR TITLE
chore(pre-commit): add conventional commit linter hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,6 @@ jobs:
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml') }}
+
+      - name: Conventional Commitlint
+        uses: opensource-nepal/commitlint@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+
+  - repo: https://github.com/opensource-nepal/commitlint
+    rev: v1.3.0
+    hooks:
+      - id: commitlint


### PR DESCRIPTION
# Description

This PR introduces a commit message linter hook to enforce the [Conventional Commits](https://www.conventionalcommits.org/) standard.

### Changes:
- Added `commit-message-linter` to `.pre-commit-config.yaml`
- Ensures all commit messages follow the `type(scope): description` format
- Validates commit messages using `--type conventional`

### Why:
Maintaining consistent and structured commit messages helps with:
- automated changelog generation,
- clean Git history,
- better code reviews and CI integrations.

### Usage:
Ensure the hook is activated:
```bash
pre-commit install --hook-type commit-msg
```

All commit messages will now be validated automatically before completing the commit.
